### PR TITLE
Add issue and pull request templates for better contribution guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug. Be as specific as possible and include steps to reproduce, expected behaviour and actual behaviour.
+        Thanks for taking the time to report a bug. Be as specific as possible and include steps to reproduce, expected behavior and actual behavior.
 
   - type: textarea
     id: steps_to_reproduce

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Create a report to help us improve. Please include steps to reproduce and environment details.
+title: "[BUG] "
+labels: [bug]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Be as specific as possible and include steps to reproduce, expected behaviour and actual behaviour.
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal set of steps to reproduce the issue.
+      placeholder: |
+        1. Do this
+        2. Do that
+        3. Observe the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+      placeholder: The command should ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened instead.
+      placeholder: The bot responded with ...
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, library versions (discord.py, etc.) and bot config relevant to reproduce.
+      placeholder: Windows 10, Python 3.11, discord.py 2.x
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is the impact of this bug?
+      options:
+        - Low
+        - Medium
+        - High
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional information
+      description: Logs, stack traces, screenshots or other files that help debugging.
+      placeholder: Paste logs or attach files.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,13 +23,13 @@ body:
     attributes:
       label: Problem statement
       description: What problem does this feature solve?
-      placeholder: Current behaviour and limitations.
+      placeholder: Current behavior and limitations.
 
   - type: textarea
     id: proposal
     attributes:
       label: Proposed solution
-      description: How should the feature work? High level details.
+      description: How should the feature work? High-level details.
       placeholder: Implementation ideas, config options, API changes.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest a new feature or improvement for the project.
+title: "[FEATURE] "
+labels: [enhancement]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature. Describe the problem you want to solve and the proposed solution.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Short summary
+      description: One-line summary of the feature.
+      placeholder: e.g. Add slash command for X
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this feature solve?
+      placeholder: Current behaviour and limitations.
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should the feature work? High level details.
+      placeholder: Implementation ideas, config options, API changes.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Low
+        - Medium
+        - High
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Examples, use-cases, or screenshots.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Reference the related issue (e.g. #123) or remove if not applicable.
 Describe the tests executed (unit, integration, manual) and steps to reproduce.
 
 ## Checklist
-- [ ] I have read the contribution guidelines.
+- [ ] I have reviewed the requirements in this template.
 - [ ] Code follows the project's style (lint/format).
 - [ ] Unit tests added or updated where applicable.
 - [ ] All CI checks are passing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!-- Short descriptive title above -->
+# Pull Request
+
+## Summary
+Provide a concise description of the change and why it is needed.
+
+## Related issue
+Reference the related issue (e.g. #123) or remove if not applicable.
+
+## Changes
+- Brief list of changes introduced by this PR.
+
+## Type of change
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Chore / maintenance
+- [ ] CI / Build
+
+## How was this tested?
+Describe the tests executed (unit, integration, manual) and steps to reproduce.
+
+## Checklist
+- [ ] I have read the contribution guidelines.
+- [ ] Code follows the project's style (lint/format).
+- [ ] Unit tests added or updated where applicable.
+- [ ] All CI checks are passing.
+- [ ] I updated documentation if needed.
+
+## Deployment / Rollout
+Any special deployment steps, migration, or feature flags required.
+
+## Notes for the reviewer
+Anything the reviewer should pay attention to (performance, breaking changes, edge cases).


### PR DESCRIPTION
This pull request adds standardized templates for GitHub issues and pull requests, aiming to improve the quality and consistency of bug reports, feature requests, and pull request submissions.

**Issue and PR Template Additions:**

*Bug report and feature request templates:*
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` to guide users in submitting detailed bug reports, including steps to reproduce, environment, severity, and additional information.
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` to help users propose new features or improvements, capturing summary, problem, proposal, alternatives, and priority.

*Pull request template:*
- Added `.github/PULL_REQUEST_TEMPLATE.md` to standardize pull request submissions, including summary, related issues, change list, testing, checklist, deployment steps, and reviewer notes.