### PR TITLE
bugfix: Update get_session method to use asynccontextmanager

### DIFF
--- a/src/services/database/database.py
+++ b/src/services/database/database.py
@@ -1,8 +1,9 @@
 # External imports:
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
-from collections.abc import AsyncGenerator
 from threading import Lock
 from typing import Optional
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
 
 # Internal imports:
 
@@ -80,14 +81,15 @@ class DatabaseService:
 
         return self._engines[name]["engine"]
 
-    async def get_session(self, name: str) -> AsyncGenerator[AsyncSession, None]:
+    @asynccontextmanager
+    async def get_session(self, name: str) -> AsyncIterator[AsyncSession]:
         """
         Retrieves an asynchronous session by the engine's name.
 
         :param name: The name of the engine to retrieve the session from.
         :type name: str
         :return: The asynchronous session associated with the given engine name.
-        :rtype: AsyncSession
+        :rtype: AsyncIterator[AsyncSession]
         """
         if name not in self._engines:
             raise ValueError(f"No engine found with the name '{name}'.")


### PR DESCRIPTION
This pull request refactors the session management in the `database.py` service to make use of Python's `@asynccontextmanager` for cleaner and safer asynchronous session handling. It also updates relevant type hints to use `AsyncIterator` instead of `AsyncGenerator`.

Session management improvements:

* Switched the `get_session` method to use the `@asynccontextmanager` decorator for better resource management and clearer usage patterns.
* Updated type hints in `get_session` from `AsyncGenerator` to `AsyncIterator` to reflect the new context manager usage and improve type safety.
* Updated imports: added `asynccontextmanager` and replaced `AsyncGenerator` with `AsyncIterator` in the import statements.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / maintenance
- [ ] CI / Build

## Checklist
- [x] I have reviewed the requirements in this template.
- [ ] Code follows the project's style (lint/format).
- [ ] Unit tests added or updated where applicable.
- [ ] All CI checks are passing.
- [x] I updated documentation if needed.
