### PR TITLE
feat: Add BotExtension and BotCommandGroup for modular bot functionality

### DIFF
--- a/src/extensions/bot/__init__.py
+++ b/src/extensions/bot/__init__.py
@@ -1,0 +1,21 @@
+# External imports:
+from discord.ext.commands import Bot
+from logging import getLogger
+
+# Internal imports:
+from .bot import BotExtension
+
+# Code:
+async def setup(bot: Bot) -> None:
+    """
+    This function is called when the extension is loaded. It can be used to set up any necessary resources or state for the extension.
+
+    :param bot: The instance of the Bot that is loading the extension.
+    :type bot: Bot
+    """
+    _logger = getLogger(__package__)
+    _logger.info("Bot extension is being loaded...")
+
+    await bot.add_cog(BotExtension(bot))
+
+    _logger.info("Bot extension loaded successfully.")

--- a/src/extensions/bot/bot.py
+++ b/src/extensions/bot/bot.py
@@ -8,7 +8,7 @@ from .components import BotCommandGroup
 # Code:
 class BotExtension(Cog):
     """
-    This is the bot extension that can be used to functions related to the bot. It includes basic functionality, for example, a command
+    This is the bot extension that can be used to handle functionality related to the bot. It includes basic functionality, for example, a command
     to check if the bot is alive. The extension is designed to be modular and can be easily integrated into the bot's architecture.
     """
     # Internal methods:

--- a/src/extensions/bot/bot.py
+++ b/src/extensions/bot/bot.py
@@ -1,0 +1,29 @@
+# External imports:
+from discord.ext.commands import Cog, Bot
+from logging import getLogger
+
+# Internal imports:
+from .components import BotCommandGroup
+
+# Code:
+class BotExtension(Cog):
+    """
+    This is the bot extension that can be used to functions related to the bot. It includes basic functionality, for example, a command
+    to check if the bot is alive. The extension is designed to be modular and can be easily integrated into the bot's architecture.
+    """
+    # Internal methods:
+    def __init__(self, bot: Bot) -> None:
+        """
+        Initializes the BotExtension.
+
+        :param bot: The instance of the Bot that is loading the extension.
+        :type bot: Bot
+        """
+        self.bot = bot
+        self.bot.tree.add_command(BotCommandGroup(bot, self))
+        self._logger = getLogger(__package__)
+        self._logger.debug("BotExtension initialized.")
+
+    # Private methods:
+
+    # Public methods:

--- a/src/extensions/bot/components/__init__.py
+++ b/src/extensions/bot/components/__init__.py
@@ -1,0 +1,7 @@
+# External imports:
+
+# Internal imports:
+from .commands import BotCommandGroup
+
+# Code:
+__all__ = ["BotCommandGroup"]

--- a/src/extensions/bot/components/commands/__init__.py
+++ b/src/extensions/bot/components/commands/__init__.py
@@ -1,0 +1,7 @@
+# External imports:
+
+# Internal imports:
+from .bot import BotCommandGroup
+
+# Code:
+__all__ = ["BotCommandGroup"]

--- a/src/extensions/bot/components/commands/bot.py
+++ b/src/extensions/bot/components/commands/bot.py
@@ -1,0 +1,58 @@
+# External imports:
+from discord.app_commands import Group, command
+from discord.ext.commands import Cog, Bot
+from logging import getLogger
+from discord import Interaction, Embed, Color
+
+# Internal imports:
+
+# Code:
+class BotCommandGroup(Group):
+    """
+    This is a command group for bot-related commands. It can be used to organize commands that are related to the bot's
+    functionality, such as checking if the bot is alive or getting information about the bot. The command group is designed to be
+    modular and can be easily integrated into the bot's architecture.
+    """
+    # Internal methods:
+    def __init__(self, bot: Bot, cog: Cog) -> None:
+        """
+        Initializes the BotCommandGroup.
+
+        :param bot: The instance of the Bot that is loading the command group.
+        :type bot: Bot
+        :param cog: The Cog that the command group belongs to.
+        :type cog: Cog
+        """
+        super().__init__(name="bot", description="Commands related to the bot.")
+        self.bot = bot
+        self.cog = cog
+        self._logger = getLogger(__package__)
+        self._logger.debug("BotCommandGroup initialized.")
+
+    # Private methods:
+
+    # Public methods:
+    @command(name="status", description="Check the status of the bot.")
+    async def status(self, interaction: Interaction) -> None:
+        """
+        This command checks the status of the bot and responds with an embedded message containing the bot's latency and a status message.
+
+        :param interaction: The interaction that triggered the command.
+        :type interaction: Interaction
+        """
+        embed = Embed(
+            title="Bot Status:",
+            description="The bot is alive and functioning properly!",
+            color=Color.blurple()
+        )
+        embed.add_field(
+            name="Ping:",
+            value=f"`{self.bot.latency * 1000:.0f} ms`",
+            inline=True
+        )
+        embed.set_footer(
+            text=f"{self.bot.user.name} is here to assist you!",
+            icon_url=self.bot.user.avatar.url if self.bot.user.avatar else None
+        )
+
+        await interaction.response.send_message(embed=embed, ephemeral=True)


### PR DESCRIPTION
This pull request introduces a modular bot extension to the codebase, organizing bot-related functionality into a clear structure using Discord's extension and command group patterns. The main changes include the creation of a `BotExtension` cog, a grouped set of bot commands (including a new `/bot status` command), and proper initialization logic for the extension.

**New bot extension and command structure:**

* Created the `BotExtension` cog class in `bot.py`, which initializes the extension and registers a command group for bot-related commands.
* Added the `setup` function in `__init__.py` to handle extension loading and logging.

**Command organization and new features:**

* Implemented the `BotCommandGroup` class in `commands/bot.py`, which defines a `/bot status` command that responds with the bot's status and latency in an embedded message.
* Set up module exports using `__all__` in relevant `__init__.py` files to expose `BotCommandGroup` for import and use. [[1]](diffhunk://#diff-e8fde5bb2794ddf249a7e6a509c064854ef76be89b6cdcac233f42e4787e1129R1-R7) [[2]](diffhunk://#diff-5a43f8f001e78c26e87df3dae05938fa79d271f51badf3a33acd8a2179151c2cR1-R7)

## Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation
- [ ] Chore / maintenance
- [ ] CI / Build

## Checklist
- [x] I have reviewed the requirements in this template.
- [ ] Code follows the project's style (lint/format).
- [ ] Unit tests added or updated where applicable.
- [ ] All CI checks are passing.
- [x] I updated documentation if needed.